### PR TITLE
Implement stop, refactor a little bit, and fix the way open log files are identified

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :url "https://github.com/staples-sparx/kits"
   :plugins [[jonase/eastwood "0.0.2"]
             [lein-kibit "0.0.7"]]
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
                  [cheshire "5.3.1"]
                  [clout "1.1.0"]
                  [org.hdrhistogram/HdrHistogram "1.2.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.sparx/kits "1.20.8-SNAPSHOT"
+(defproject org.clojars.sparx/kits "1.20.8-r1"
   :description "Runa's core utilities."
   :local-repo ".m2"
   :min-lein-version "2.0.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.sparx/kits "1.21.8-SNAPSHOT"
+(defproject org.clojars.sparx/kits "1.20.8-SNAPSHOT"
   :description "Runa's core utilities."
   :local-repo ".m2"
   :min-lein-version "2.0.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.sparx/kits "1.21.0-SNAPSHOT"
+(defproject org.clojars.sparx/kits "1.21.8-SNAPSHOT"
   :description "Runa's core utilities."
   :local-repo ".m2"
   :min-lein-version "2.0.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.sparx/kits "1.20.7"
+(defproject org.clojars.sparx/kits "1.21.0-SNAPSHOT"
   :description "Runa's core utilities."
   :local-repo ".m2"
   :min-lein-version "2.0.0"

--- a/src/kits/high_throughput_logging.clj
+++ b/src/kits/high_throughput_logging.clj
@@ -34,7 +34,7 @@
   "Build a loop that can be used in a thread pool to log entry with a
   very high-troughput rate. Code is quite ugly but by lazily rotating
   and flushing the writer we achieve very troughput."
-  [{:keys [queue compute-file-name formatter io-error-handler conf run-switch]}]
+  [{:keys [queue compute-file-name formatter io-error-handler conf]}]
   (let [{:keys [queue-timeout-ms rotate-every-minute max-unflushed max-elapsed-unflushed-ms]} conf
         compute-next-rotate-at (fn [now]
                                  (cal/round-up-ts now rotate-every-minute))

--- a/src/kits/high_throughput_logging.clj
+++ b/src/kits/high_throughput_logging.clj
@@ -30,75 +30,63 @@
       thread-id
       ".log")))
 
+(defn- next-rotate-time [now rotation-minutes]
+  (cal/round-up-ts now rotation-minutes))
+
+(defn- format-log-entry [formatter msg]
+  (let [host (runtime/host)
+        pid (runtime/process-id)
+        tid (runtime/thread-id)]
+    (try
+      (formatter host pid tid msg)
+      (catch Throwable e
+        (.printStackTrace e)))))
+
+(defn- create-log-file-writer [file-name-fn ts-ms]
+  (let [path (file-name-fn (runtime/thread-id) ts-ms)]
+    (FileWriter. ^String path true)))
+
+(defn- rotate-log [create-writer writer io-error-handler rotate-at]
+  (io/resilient-close writer io-error-handler)
+  (create-writer rotate-at))
+
 (defn make-log-rotate-loop
-  "Build a loop that can be used in a thread pool to log entry with a
-  very high-troughput rate. Code is quite ugly but by lazily rotating
-  and flushing the writer we achieve very troughput."
+  "Build a loop to write log entries with a high-throughput rate."
   [{:keys [queue compute-file-name formatter io-error-handler conf]}]
-  (let [{:keys [queue-timeout-ms rotate-every-minute max-unflushed max-elapsed-unflushed-ms]} conf
-        compute-next-rotate-at (fn [now]
-                                 (cal/round-up-ts now rotate-every-minute))
-        log-file-for (fn [ts]
-                       (let [path (compute-file-name (runtime/thread-id) ts)]
-                         {:path path
-                          :writer (FileWriter. ^String path true)}))]
-    (fn [thread-name args]
-      (let [now (ms-time)
-            rotate-at (compute-next-rotate-at now)
-            {:keys [path writer]}  (log-file-for rotate-at)
-            host (runtime/host)
-            pid (runtime/process-id)
-            tid (runtime/thread-id)
-            entry-formatter (fn [msg]
-                              (try
-                                (formatter host pid tid msg)
-                                (catch Throwable e
-                                  (.printStackTrace e))))]
-        ;; (log/info "Starting thread writing to " path)
-        (loop [last-flush-at now
-               unflushed 0
-               rotate-at rotate-at
-               writer writer]
-          ;; (log/debug thread-name " | Fetching a message...")
-          (let [msg (q/fetch queue queue-timeout-ms)
-                terminate? (= ::terminate msg)
-                now (ms-time)
-                ;; Check whether we should rotate the logs
-                rotate? (> now rotate-at)
-                rotate-at (if-not rotate?
-                            rotate-at
-                            (compute-next-rotate-at now))
-                writer (if-not rotate?
-                         writer
-                         (do
-                           (io/resilient-close writer io-error-handler)
-                           (:writer (log-file-for rotate-at))))]
-            (if (or terminate? (not msg))
-              ;; Check whether we should flush and get back to business
-              (if (and
-                    (pos? unflushed)
-                    (or (> (- now last-flush-at) max-elapsed-unflushed-ms)
-                        terminate?))
-                (do
-                  ;; (log/debug "Flush inactive")
-                  (io/resilient-flush ^FileWriter writer io-error-handler)
-                  (when (not terminate?)
-                    (recur (ms-time) 0 rotate-at writer)))
-                (when (not terminate?)
-                  (recur last-flush-at unflushed rotate-at writer)))
-
-              ;; Write log entry, flushing lazily
-              (do
-                ;; (log/debug "Got msg" msg)
-                (io/resilient-write writer (str (entry-formatter msg) "\n") io-error-handler)
-
-                (if (or (> (- now last-flush-at) max-elapsed-unflushed-ms)
-                      (> unflushed max-unflushed))
-                  (do
-                    ;; (log/debug "Flush")
-                    (io/resilient-flush writer io-error-handler)
-                    (recur (ms-time) 0 rotate-at writer))
-                  (recur last-flush-at (inc unflushed) rotate-at writer))))))))))
+  (fn [thread-name args]
+    (let [{:keys [queue-timeout-ms rotate-every-minute max-unflushed max-elapsed-unflushed-ms]} conf
+          create-log-file-for (partial create-log-file-writer compute-file-name)
+          entry-formatter (partial format-log-entry formatter)]
+      (loop [last-flush-at (ms-time)
+             unflushed 0
+             rotate-at (next-rotate-time last-flush-at rotate-every-minute)
+             writer (create-log-file-for rotate-at)]
+        (let [msg (q/fetch queue queue-timeout-ms)
+              now (ms-time)
+              terminate? (= ::terminate msg)
+              rotate? (> now rotate-at)
+              [rotate-at writer unflushed] (if rotate?
+                                             [(next-rotate-time now rotate-every-minute)
+                                              (rotate-log create-log-file-for writer io-error-handler rotate-at) 
+                                              0]
+                                             [rotate-at writer unflushed])
+              is-log-msg? (and (not terminate?) (boolean msg)) ; msg is not false or nil (flush heartbeat triggers)
+              unflushed (if is-log-msg? 
+                          (do
+                            (io/resilient-write writer (str (entry-formatter msg) "\n") io-error-handler)
+                            (inc unflushed))
+                          unflushed)
+              flush? (and (pos? unflushed) ; have some unflushed data
+                          (or terminate? ; stopping the loop
+                              (> (- now last-flush-at) max-elapsed-unflushed-ms) ; unflushed time limit
+                              (> unflushed max-unflushed)))] ; unflushed count limit
+          (if flush?
+            (do
+              (io/resilient-flush writer io-error-handler)
+              (when-not terminate?
+                (recur (ms-time) 0 rotate-at writer)))
+            (when-not terminate?
+              (recur last-flush-at unflushed rotate-at writer))))))))
 
 (defn stop-log-rotate-loop [queue]
   (q/add queue ::terminate))

--- a/src/kits/high_throughput_logging.clj
+++ b/src/kits/high_throughput_logging.clj
@@ -10,6 +10,8 @@
   (:import
     java.io.FileWriter))
 
+(def ^:private open-file-suffix ".open")
+
 (defn std-log-file-path-fn
   "Convenience function which return a function can be used as the
    compute-file-name setting when calling make-log-rotate-loop. Write
@@ -42,51 +44,60 @@
       (catch Throwable e
         (.printStackTrace e)))))
 
-(defn- create-log-file-writer [file-name-fn ts-ms]
-  (let [path (file-name-fn (runtime/thread-id) ts-ms)]
-    (FileWriter. ^String path true)))
+(defn- create-log-file [file-name-fn ts-ms]
+  (let [path (str (file-name-fn (runtime/thread-id) ts-ms))
+        open-path (str path open-file-suffix)]
+    {:open-path open-path
+     :dest-path path
+     :writer (FileWriter. ^String open-path true)}))
 
-(defn- rotate-log [create-writer writer io-error-handler rotate-at]
-  (io/resilient-close writer io-error-handler)
-  (create-writer rotate-at))
+(defn- close-log [log-file io-error-handler]
+  (io/resilient-close (:writer log-file) io-error-handler)
+  (io/resilient-move (:open-path log-file) (:dest-path log-file) io-error-handler))
+
+(defn- rotate-log [new-log log-file io-error-handler rotate-at]
+  (close-log log-file io-error-handler)
+  (new-log rotate-at))
 
 (defn make-log-rotate-loop
   "Build a loop to write log entries with a high-throughput rate."
   [{:keys [queue compute-file-name formatter io-error-handler conf]}]
   (fn [thread-name args]
     (let [{:keys [queue-timeout-ms rotate-every-minute max-unflushed max-elapsed-unflushed-ms]} conf
-          create-log-file-for (partial create-log-file-writer compute-file-name)
+          create-log-file-for (partial create-log-file compute-file-name)
           entry-formatter (partial format-log-entry formatter)]
       (loop [last-flush-at (ms-time)
              unflushed 0
              rotate-at (next-rotate-time last-flush-at rotate-every-minute)
-             writer (create-log-file-for rotate-at)]
+             log-file (create-log-file-for rotate-at)]
         (let [msg (q/fetch queue queue-timeout-ms)
               now (ms-time)
               terminate? (= ::terminate msg)
               rotate? (> now rotate-at)
-              [rotate-at writer unflushed] (if rotate?
+              [rotate-at log-file unflushed] (if rotate?
                                              [(next-rotate-time now rotate-every-minute)
-                                              (rotate-log create-log-file-for writer io-error-handler rotate-at) 
+                                              (rotate-log create-log-file-for log-file io-error-handler rotate-at) 
                                               0]
-                                             [rotate-at writer unflushed])
+                                             [rotate-at log-file unflushed])
               is-log-msg? (and (not terminate?) (boolean msg)) ; msg is not false or nil (flush heartbeat triggers)
               unflushed (if is-log-msg? 
                           (do
-                            (io/resilient-write writer (str (entry-formatter msg) "\n") io-error-handler)
+                            (io/resilient-write (:writer log-file)
+                                                (str (entry-formatter msg) "\n")
+                                                io-error-handler)
                             (inc unflushed))
                           unflushed)
               flush? (and (pos? unflushed) ; have some unflushed data
                           (or terminate? ; stopping the loop
                               (> (- now last-flush-at) max-elapsed-unflushed-ms) ; unflushed time limit
                               (> unflushed max-unflushed)))] ; unflushed count limit
-          (if flush?
-            (do
-              (io/resilient-flush writer io-error-handler)
-              (when-not terminate?
-                (recur (ms-time) 0 rotate-at writer)))
-            (when-not terminate?
-              (recur last-flush-at unflushed rotate-at writer))))))))
+          (if terminate?
+            (close-log log-file io-error-handler)
+            (if flush?
+              (do
+                (io/resilient-flush (:writer log-file) io-error-handler)
+                (recur (ms-time) 0 rotate-at log-file))
+              (recur last-flush-at unflushed rotate-at log-file))))))))
 
 (defn stop-log-rotate-loop [queue]
   (q/add queue ::terminate))

--- a/src/kits/io.clj
+++ b/src/kits/io.clj
@@ -178,6 +178,17 @@
     (catch IOException e
       (error-callback e))))
 
+(defn resilient-move
+  "Move src-path to dest-path, forwarding any exceptions to error-callback"
+  [src-path dest-path error-callback]
+  (try
+    (let [src-file (File. ^String src-path)
+          dest-file (File. ^String dest-path)]
+      (when-not (.renameTo src-file dest-file)
+        (throw (IOException. (str "Failed to rename file from: '" src-path "' to: '" dest-path "'")))))
+    (catch IOException e
+      (error-callback e))))
+
 (defn clj?
   "Returns true if file is a normal file with a .clj extension."
   [^File file]

--- a/src/kits/queues.clj
+++ b/src/kits/queues.clj
@@ -81,8 +81,8 @@
 (defn- safe-thread-join [any-ex timeout-ms thread]
   (try 
     (if (some? timeout-ms)
-      (.join thread (long timeout-ms))
-      (.join thread))
+      (.join ^Thread thread (long timeout-ms))
+      (.join ^Thread thread))
     (catch InterruptedException e
       (when (nil? @any-ex)
       (var-set any-ex e))))

--- a/src/kits/queues.clj
+++ b/src/kits/queues.clj
@@ -71,8 +71,22 @@
    when invoking 'start-thread-pool'"
   [thread-count name-prefix f & args]
   (doall
-    (map #(let [name (str name-prefix %)
+    (map (fn [thread-num]
+           (let [name (str name-prefix thread-num)
                 t (Thread. ^Runnable (partial f name args) ^String name)]
             (.start t)
-            t)
-      (range 0 (int thread-count)))))
+            t))
+         (range 0 (int thread-count)))))
+
+(defn join-thread-pool
+  "Join all threads in a thread pool."
+  ([pool] (join-thread-pool pool nil))
+  ([pool timeout-ms]
+    (doall
+      (map (fn [thread]
+             (if timeout-ms
+               (.join thread (long timeout-ms))
+               (.join thread))
+             thread)
+           pool))))
+


### PR DESCRIPTION
- Necessary functionality to gracefully stop log writer threads
- Upgrade to Clojure 1.6.0
- Refactor make-log-rotate-loop for readability + maintainability
- Identify open log files with ".open" file name suffix so they can be identified by external processes
